### PR TITLE
chore: update Node.js to 24.15.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 24.14.1
+nodejs 24.15.0
 pnpm 10.33.0


### PR DESCRIPTION
## Summary

- Bumps Node.js from `24.14.1` → `24.15.0` (latest LTS release, April 15 2026) in `.tool-versions`

All npm dependencies (`next`, `prisma`, `@tanstack/react-query`, `tailwindcss`, `zod`, etc.) were audited and are already at their latest versions. pnpm remains at `10.33.0` (latest stable).

## Test plan
- [ ] CI passes with the updated Node.js version